### PR TITLE
added node binary as a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ the_island_node_sass:
 * **style** - see `--output-style` in `node-sass -h`
 * **debug** - turns on `--source-comments`
 * **load_paths** - adds paths to `--include-path`
+* **node** - path to your local node (might help if node is not on your path)
+ 

--- a/src/TheIsland/NodeSassBundle/Assetic/Filter/NodeSassFilter.php
+++ b/src/TheIsland/NodeSassBundle/Assetic/Filter/NodeSassFilter.php
@@ -4,6 +4,7 @@ namespace TheIsland\NodeSassBundle\Assetic\Filter;
 use Assetic\Asset\AssetInterface;
 use Assetic\Exception\FilterException;
 use Assetic\Filter\Sass\BaseSassFilter;
+use Symfony\Component\Process\ProcessBuilder;
 
 class NodeSassFilter extends BaseSassFilter
 {
@@ -13,14 +14,13 @@ class NodeSassFilter extends BaseSassFilter
     const STYLE_COMPRESSED = 'compressed';
 
     private $sassPath;
-    private $rubyPath;
     private $nodePath;
 
     private $style;
     private $debugInfo;
     private $sourceMap;
 
-    public function __construct($sassPath = '/usr/bin/node-sass', $rubyPath = '', $nodePath = null)
+    public function __construct($sassPath = '/usr/bin/node-sass', $nodePath = null)
     {
         $this->sassPath = $sassPath;
         $this->nodePath = $nodePath;
@@ -44,8 +44,9 @@ class NodeSassFilter extends BaseSassFilter
     public function filterLoad(AssetInterface $asset)
     {
         $sassProcessArgs = array();
-        if (null !== $this->nodePath)
+        if (null !== $this->nodePath) {
             $sassProcessArgs[] = $this->nodePath;
+        }
 
         $sassProcessArgs[] = $this->sassPath;
 

--- a/src/TheIsland/NodeSassBundle/Assetic/Filter/NodeSassFilter.php
+++ b/src/TheIsland/NodeSassBundle/Assetic/Filter/NodeSassFilter.php
@@ -14,13 +14,16 @@ class NodeSassFilter extends BaseSassFilter
 
     private $sassPath;
     private $rubyPath;
+    private $nodePath;
+
     private $style;
     private $debugInfo;
     private $sourceMap;
 
-    public function __construct($sassPath = '/usr/bin/node-sass')
+    public function __construct($sassPath = '/usr/bin/node-sass', $rubyPath = '', $nodePath = null)
     {
         $this->sassPath = $sassPath;
+        $this->nodePath = $nodePath;
     }
 
     public function setStyle($style)
@@ -40,7 +43,11 @@ class NodeSassFilter extends BaseSassFilter
 
     public function filterLoad(AssetInterface $asset)
     {
-        $sassProcessArgs = array($this->sassPath);
+        $sassProcessArgs = array();
+        if (null !== $this->nodePath)
+            $sassProcessArgs[] = $this->nodePath;
+
+        $sassProcessArgs[] = $this->sassPath;
 
         $pb = $this->createProcessBuilder($sassProcessArgs);
 

--- a/src/TheIsland/NodeSassBundle/DependencyInjection/Configuration.php
+++ b/src/TheIsland/NodeSassBundle/DependencyInjection/Configuration.php
@@ -14,7 +14,7 @@ class Configuration implements ConfigurationInterface {
             ->children()
                 ->scalarNode('apply_to')->end()
                 ->scalarNode('bin')->end()
-                ->scalarNode('node')->end()
+                ->scalarNode('node')->defaultNull()->end()
                 ->scalarNode('style')->end()
                 ->booleanNode('debug')->defaultFalse()->end()
                 ->arrayNode('load_paths')->prototype('scalar')->end()

--- a/src/TheIsland/NodeSassBundle/DependencyInjection/Configuration.php
+++ b/src/TheIsland/NodeSassBundle/DependencyInjection/Configuration.php
@@ -14,6 +14,7 @@ class Configuration implements ConfigurationInterface {
             ->children()
                 ->scalarNode('apply_to')->end()
                 ->scalarNode('bin')->end()
+                ->scalarNode('node')->end()
                 ->scalarNode('style')->end()
                 ->booleanNode('debug')->defaultFalse()->end()
                 ->arrayNode('load_paths')->prototype('scalar')->end()

--- a/src/TheIsland/NodeSassBundle/Resources/config/services.xml
+++ b/src/TheIsland/NodeSassBundle/Resources/config/services.xml
@@ -8,7 +8,6 @@
         <parameter key="the_island.assetic.filter.node_scss.class">TheIsland\NodeSassBundle\Assetic\Filter\NodeSassFilter</parameter>
         <parameter key="the_island.assetic.filter.node_scss.bin">/usr/bin/node-sass</parameter>
         <parameter key="the_island.assetic.filter.node_scss.node">null</parameter>
-        <parameter key="the_island.assetic.filter.node_scss.ruby">%assetic.ruby.bin%</parameter>
         <parameter key="the_island.assetic.filter.node_scss.style">null</parameter>
         <parameter key="the_island.assetic.filter.node_scss.source_map">false</parameter>
         <parameter key="the_island.assetic.filter.node_scss.debug">%kernel.debug%</parameter>
@@ -21,7 +20,6 @@
         <service id="the_island.assetic.filter.node_scss" class="%the_island.assetic.filter.node_scss.class%">
             <tag name="assetic.filter" alias="node_scss" />
             <argument>%the_island.assetic.filter.node_scss.bin%</argument>
-            <argument>%the_island.assetic.filter.node_scss.ruby%</argument>
             <argument>%the_island.assetic.filter.node_scss.node%</argument>
             <call method="setStyle"><argument>%the_island.assetic.filter.node_scss.style%</argument></call>
             <call method="setSourceMap"><argument>%the_island.assetic.filter.node_scss.source_map%</argument></call>

--- a/src/TheIsland/NodeSassBundle/Resources/config/services.xml
+++ b/src/TheIsland/NodeSassBundle/Resources/config/services.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="the_island.assetic.filter.node_scss.class">TheIsland\NodeSassBundle\Assetic\Filter\NodeSassFilter</parameter>
         <parameter key="the_island.assetic.filter.node_scss.bin">/usr/bin/node-sass</parameter>
+        <parameter key="the_island.assetic.filter.node_scss.node">null</parameter>
         <parameter key="the_island.assetic.filter.node_scss.ruby">%assetic.ruby.bin%</parameter>
         <parameter key="the_island.assetic.filter.node_scss.style">null</parameter>
         <parameter key="the_island.assetic.filter.node_scss.source_map">false</parameter>
@@ -21,6 +22,7 @@
             <tag name="assetic.filter" alias="node_scss" />
             <argument>%the_island.assetic.filter.node_scss.bin%</argument>
             <argument>%the_island.assetic.filter.node_scss.ruby%</argument>
+            <argument>%the_island.assetic.filter.node_scss.node%</argument>
             <call method="setStyle"><argument>%the_island.assetic.filter.node_scss.style%</argument></call>
             <call method="setSourceMap"><argument>%the_island.assetic.filter.node_scss.source_map%</argument></call>
             <call method="setDebugInfo"><argument>%the_island.assetic.filter.node_scss.debug%</argument></call>


### PR DESCRIPTION
I stumbled upon a problem when I integrated your project into my asset pipeline: 

```
[exception] 500 | Internal Server Error | Assetic\Exception\FilterException
[message] An error occurred while running:
'/Users/stefan/.npm-packages/lib/node_modules/node-sass/bin/node-sass' '--include-path' '/Users/stefan/work/web-fsv/apps/fsv/src/Fsv/ComparisonBundle/Resources/public/scss' '--output-style' 'nested' '--include-path' '/Users/stefan/work/web-fsv/apps/fsv/app/../vendor' '/private/var/tmp/assetic_sasssJfSBK' '--stdout'

Error Output:
env: node: No such file or directory
```

I added an option to configure the node executable as well and now it's running correctly: it's basically prepending /usr/local/bin/node to the cli. 

The option is backwards compatible: if one doesn't need it, he can omit it.
